### PR TITLE
Move to an await based loader

### DIFF
--- a/scriptable-api/pages/index.tsx
+++ b/scriptable-api/pages/index.tsx
@@ -70,8 +70,8 @@ const setWidgetModule = (widgetLoader: string, rootUrl: string, widgetModule?: W
     return widgetLoader;
   }
   let filled = widgetLoader;
-  const { fileName, meta } = widgetModule;
-  const args = { fileName, ...meta.loaderArgs, rootUrl: rootUrl, widgetParameter: widgetParameter };
+  const { moduleName, meta } = widgetModule;
+  const args = { moduleName, ...meta.loaderArgs, rootUrl: rootUrl, widgetParameter: widgetParameter };
 
   for (let arg of Object.keys(args)) {
     const reg = new RegExp(`__${arg}__`, "gim")
@@ -140,9 +140,9 @@ export default function Page({ widgetLoader, widgetModules }: PageProps) {
             {widgetModules.map(wm =>
               <WidgetModuleCard
                 widgetModule={wm}
-                key={wm.fileName}
+                key={wm.moduleName}
                 onSelect={() => setSelectedModule(wm)}
-                isSelected={wm.fileName === selectedModule?.fileName} />
+                isSelected={wm.moduleName === selectedModule?.moduleName} />
             )}
             <Paper className={classes.paperComingSoon} >
               <Typography variant="caption" color="textSecondary" component="div" style={{ marginTop: 68 }}>
@@ -237,16 +237,16 @@ export default function Page({ widgetLoader, widgetModules }: PageProps) {
 
 export const getStaticProps: GetStaticProps<{}, {}> = async ({ params }) => {
   const widgetLoaderPath = resolve('./public/compiled-widgets/widgetLoader.js');
-  const widgetModuleFilenames = ["stickyWidgetModule", "covid19WidgetModule"]
+  const widgetModuleModuleNames = ["stickyWidgetModule", "covid19WidgetModule"]
   const props: PageProps = {
     widgetLoader: readFileSync(widgetLoaderPath).toString("utf-8"),
-    widgetModules: widgetModuleFilenames.map(fileName => {
-      const rawScript = readFileSync(resolve(`./public/compiled-widgets/widget-modules/${fileName}.js`)).toString("utf-8");
-      const meta = JSON.parse(readFileSync(resolve(`./public/compiled-widgets/widget-modules/${fileName}.meta.json`)).toString("utf-8")) as WidgetModule["meta"];
+    widgetModules: widgetModuleModuleNames.map(moduleName => {
+      const rawScript = readFileSync(resolve(`./public/compiled-widgets/widget-modules/${moduleName}.js`)).toString("utf-8");
+      const meta = JSON.parse(readFileSync(resolve(`./public/compiled-widgets/widget-modules/${moduleName}.meta.json`)).toString("utf-8")) as WidgetModule["meta"];
       return ({
         rawScript,
-        fileName,
-        imageSrc: `/compiled-widgets/widget-modules/${fileName}.png`,
+        moduleName,
+        imageSrc: `/compiled-widgets/widget-modules/${moduleName}.png`,
         meta
       })
     })

--- a/scriptable-api/public/compiled-widgets/widgetLoader.js
+++ b/scriptable-api/public/compiled-widgets/widgetLoader.js
@@ -3,84 +3,73 @@
 // These must be at the very top of the file. Do not edit.
 // icon-color: __iconColor__; icon-glyph: __iconGlyph__;
 
-(function () {
-
-    const argsConfig = {
-        fileName: "__fileName__",
-        rootUrl: "__rootUrl__",
-        widgetParameter: "__widgetParameter__",
-        downloadQueryString: "__downloadQueryString__",
-    };
-    const enforceDir = (fm, path) => {
-        if (fm.fileExists(path) && !fm.isDirectory(path)) {
-            fm.remove(path);
-        }
-        if (!fm.fileExists(path)) {
-            fm.createDirectory(path);
-        }
-    };
-    async function downloadWidgetModule({ fileName, rootUrl, downloadQueryString }, forceDownload = false) {
-        const fm = FileManager.local();
-        // const scriptPath = module.filename
-        const widgetLoaderDir = fm.joinPath(fm.libraryDirectory(), "widget-loader");
-        enforceDir(fm, widgetLoaderDir);
-        const widgetModuleDir = fm.joinPath(widgetLoaderDir, fileName);
-        enforceDir(fm, widgetModuleDir);
-        const widgetModuleFilename = fileName + '.js';
-        const widgetModuleEtag = fileName + '.etag';
-        const widgetModulePath = fm.joinPath(widgetModuleDir, widgetModuleFilename);
-        const widgetModuleEtagPath = fm.joinPath(widgetModuleDir, widgetModuleEtag);
-        const widgetModuleDownloadUrl = rootUrl + widgetModuleFilename + (downloadQueryString.startsWith("?") ? downloadQueryString : "");
-        // Check if an etag was saved for this file
-        if (fm.fileExists(widgetModuleEtagPath) && !forceDownload) {
-            const lastEtag = fm.readString(widgetModuleEtagPath);
-            const headerReq = new Request(widgetModuleDownloadUrl);
-            headerReq.method = "HEAD";
-            await headerReq.load();
-            const etag = getResponseHeader(headerReq, "Etag");
-            if (lastEtag === etag) {
-                console.log(`ETag is same, return cached file for ${widgetModuleDownloadUrl}`);
-                return widgetModulePath;
-            }
-        }
-        console.log("Downloading library file '" + widgetModuleDownloadUrl + "' to '" + widgetModulePath + "'");
-        const req = new Request(widgetModuleDownloadUrl);
-        const libraryFile = await req.load();
-        const etag = getResponseHeader(req, "Etag");
-        if (etag) {
-            fm.writeString(widgetModuleEtagPath, etag);
-        }
-        fm.write(widgetModulePath, libraryFile);
-        return widgetModulePath;
+const argsConfig = {
+    fileName: "__fileName__",
+    rootUrl: "__rootUrl__",
+    widgetParameter: "__widgetParameter__",
+    downloadQueryString: "__downloadQueryString__",
+};
+const enforceDir = (fm, path) => {
+    if (fm.fileExists(path) && !fm.isDirectory(path)) {
+        fm.remove(path);
     }
-    const getResponseHeader = (request, header) => {
-        if (!request.response) {
-            return undefined;
+    if (!fm.fileExists(path)) {
+        fm.createDirectory(path);
+    }
+};
+async function downloadWidgetModule({ fileName, rootUrl, downloadQueryString }, forceDownload = false) {
+    const fm = FileManager.local();
+    // const scriptPath = module.filename
+    const widgetLoaderDir = fm.joinPath(fm.libraryDirectory(), "widget-loader");
+    enforceDir(fm, widgetLoaderDir);
+    const widgetModuleDir = fm.joinPath(widgetLoaderDir, fileName);
+    enforceDir(fm, widgetModuleDir);
+    const widgetModuleFilename = fileName + '.js';
+    const widgetModuleEtag = fileName + '.etag';
+    const widgetModulePath = fm.joinPath(widgetModuleDir, widgetModuleFilename);
+    const widgetModuleEtagPath = fm.joinPath(widgetModuleDir, widgetModuleEtag);
+    const widgetModuleDownloadUrl = rootUrl + widgetModuleFilename + (downloadQueryString.startsWith("?") ? downloadQueryString : "");
+    // Check if an etag was saved for this file
+    if (fm.fileExists(widgetModuleEtagPath) && !forceDownload) {
+        const lastEtag = fm.readString(widgetModuleEtagPath);
+        const headerReq = new Request(widgetModuleDownloadUrl);
+        headerReq.method = "HEAD";
+        await headerReq.load();
+        const etag = getResponseHeader(headerReq, "Etag");
+        if (lastEtag === etag) {
+            console.log(`ETag is same, return cached file for ${widgetModuleDownloadUrl}`);
+            return widgetModulePath;
         }
-        const key = Object.keys(request.response["headers"])
-            .find(key => key.toLowerCase() === header.toLowerCase());
-        return key ? request.response["headers"][key] : undefined;
-    };
+    }
+    console.log("Downloading library file '" + widgetModuleDownloadUrl + "' to '" + widgetModulePath + "'");
+    const req = new Request(widgetModuleDownloadUrl);
+    const libraryFile = await req.load();
+    const etag = getResponseHeader(req, "Etag");
+    if (etag) {
+        fm.writeString(widgetModuleEtagPath, etag);
+    }
+    fm.write(widgetModulePath, libraryFile);
+    return widgetModulePath;
+}
+const getResponseHeader = (request, header) => {
+    if (!request.response) {
+        return undefined;
+    }
+    const key = Object.keys(request.response["headers"])
+        .find(key => key.toLowerCase() === header.toLowerCase());
+    return key ? request.response["headers"][key] : undefined;
+};
 
-    const DEBUG = false;
-    downloadWidgetModule(argsConfig)
-        .then(async (widgetModulePath) => {
-        // import downloaded widgetModule
-        const widgetModule = importModule(widgetModulePath);
-        // create the widget
-        const params = {
-            widgetParameter: args.widgetParameter || argsConfig.widgetParameter,
-            debug: DEBUG
-        };
-        const widget = await widgetModule.createWidget(params);
-        // preview the widget
-        if (!config.runsInWidget) {
-            await widget.presentSmall();
-        }
-        Script.setWidget(widget);
-        Script.complete();
-    }).catch(error => {
-        console.error(error);
-    });
-
-}());
+const DEBUG = false;
+const widgetModulePath = await downloadWidgetModule(argsConfig);
+const widgetModule = importModule(widgetModulePath);
+const widget = await widgetModule.createWidget({
+    widgetParameter: args.widgetParameter || argsConfig.widgetParameter,
+    debug: DEBUG
+});
+// preview the widget if in app
+if (!config.runsInWidget) {
+    await widget.presentSmall();
+}
+Script.setWidget(widget);
+Script.complete();

--- a/scriptable-api/public/compiled-widgets/widgetLoader.js
+++ b/scriptable-api/public/compiled-widgets/widgetLoader.js
@@ -3,10 +3,10 @@
 // These must be at the very top of the file. Do not edit.
 // icon-color: __iconColor__; icon-glyph: __iconGlyph__;
 
-const argsConfig = {
-    fileName: "__fileName__",
+const widgetModuleDownloadConfig = {
+    moduleName: "__moduleName__",
     rootUrl: "__rootUrl__",
-    widgetParameter: "__widgetParameter__",
+    defaultWidgetParameter: "__defaultWidgetParameter__",
     downloadQueryString: "__downloadQueryString__",
 };
 const enforceDir = (fm, path) => {
@@ -17,15 +17,15 @@ const enforceDir = (fm, path) => {
         fm.createDirectory(path);
     }
 };
-async function downloadWidgetModule({ fileName, rootUrl, downloadQueryString }, forceDownload = false) {
+const ROOT_MODULE_PATH = "widget-loader";
+async function getOrCreateWidgetModule({ moduleName, rootUrl, downloadQueryString }, forceDownload = false) {
     const fm = FileManager.local();
-    // const scriptPath = module.filename
-    const widgetLoaderDir = fm.joinPath(fm.libraryDirectory(), "widget-loader");
+    const widgetLoaderDir = fm.joinPath(fm.libraryDirectory(), ROOT_MODULE_PATH);
     enforceDir(fm, widgetLoaderDir);
-    const widgetModuleDir = fm.joinPath(widgetLoaderDir, fileName);
+    const widgetModuleDir = fm.joinPath(widgetLoaderDir, moduleName);
     enforceDir(fm, widgetModuleDir);
-    const widgetModuleFilename = fileName + '.js';
-    const widgetModuleEtag = fileName + '.etag';
+    const widgetModuleFilename = `${moduleName}.js`;
+    const widgetModuleEtag = `${moduleName}.etag`;
     const widgetModulePath = fm.joinPath(widgetModuleDir, widgetModuleFilename);
     const widgetModuleEtagPath = fm.joinPath(widgetModuleDir, widgetModuleEtag);
     const widgetModuleDownloadUrl = rootUrl + widgetModuleFilename + (downloadQueryString.startsWith("?") ? downloadQueryString : "");
@@ -61,10 +61,11 @@ const getResponseHeader = (request, header) => {
 };
 
 const DEBUG = false;
-const widgetModulePath = await downloadWidgetModule(argsConfig);
+const FORCE_DOWNLOAD = false;
+const widgetModulePath = await getOrCreateWidgetModule(widgetModuleDownloadConfig, FORCE_DOWNLOAD);
 const widgetModule = importModule(widgetModulePath);
 const widget = await widgetModule.createWidget({
-    widgetParameter: args.widgetParameter || argsConfig.widgetParameter,
+    widgetParameter: args.widgetParameter || widgetModuleDownloadConfig.defaultWidgetParameter,
     debug: DEBUG
 });
 // preview the widget if in app

--- a/scriptable-api/src/interfaces.ts
+++ b/scriptable-api/src/interfaces.ts
@@ -1,6 +1,6 @@
 export interface WidgetModule {
     rawScript: string;
-    fileName: string;
+    moduleName: string;
     imageSrc: string;
     meta: {
         name: string;

--- a/widgets/code/utils.ts
+++ b/widgets/code/utils.ts
@@ -6,17 +6,17 @@ export interface WidgetModule {
     createWidget: (params: WidgetModuleParams) => Promise<ListWidget>;
 }
 
-interface DownloadWidgetModuleArgs {
-    fileName: string;
+interface WidgetModuleDownloadConfig {
+    moduleName: string;
     rootUrl: string;
-    widgetParameter: string;
+    defaultWidgetParameter: string;
     downloadQueryString: string;
 }
 
-export const argsConfig: DownloadWidgetModuleArgs = {
-    fileName: "__fileName__",
+export const widgetModuleDownloadConfig: WidgetModuleDownloadConfig = {
+    moduleName: "__moduleName__",
     rootUrl: "__rootUrl__",
-    widgetParameter: "__widgetParameter__",
+    defaultWidgetParameter: "__defaultWidgetParameter__",
     downloadQueryString: "__downloadQueryString__",
 }
 
@@ -86,18 +86,22 @@ const enforceDir = (fm: FileManager, path: string) => {
     }
 }
 
-async function downloadWidgetModule({ fileName, rootUrl, downloadQueryString }: DownloadWidgetModuleArgs, forceDownload = false) {
-    const fm = FileManager.local()
-    // const scriptPath = module.filename
+const ROOT_MODULE_PATH = "widget-loader";
 
-    const widgetLoaderDir = fm.joinPath(fm.libraryDirectory(), "widget-loader")
+async function getOrCreateWidgetModule(
+    { moduleName, rootUrl, downloadQueryString }: WidgetModuleDownloadConfig,
+    forceDownload = false
+) {
+    const fm = FileManager.local()
+
+    const widgetLoaderDir = fm.joinPath(fm.libraryDirectory(), ROOT_MODULE_PATH)
     enforceDir(fm, widgetLoaderDir);
 
-    const widgetModuleDir = fm.joinPath(widgetLoaderDir, fileName)
+    const widgetModuleDir = fm.joinPath(widgetLoaderDir, moduleName)
     enforceDir(fm, widgetModuleDir);
 
-    const widgetModuleFilename = fileName + '.js'
-    const widgetModuleEtag = fileName + '.etag'
+    const widgetModuleFilename = `${moduleName}.js`
+    const widgetModuleEtag = `${moduleName}.etag`
     const widgetModulePath = fm.joinPath(widgetModuleDir, widgetModuleFilename)
     const widgetModuleEtagPath = fm.joinPath(widgetModuleDir, widgetModuleEtag)
     const widgetModuleDownloadUrl = rootUrl + widgetModuleFilename + (downloadQueryString.startsWith("?") ? downloadQueryString : "")
@@ -137,6 +141,6 @@ const getResponseHeader = (request: Request, header: string) => {
 }
 
 
-export { createTextWidget, createErrorWidget, handleError, downloadWidgetModule }
+export { createTextWidget, createErrorWidget, handleError, getOrCreateWidgetModule }
 
 

--- a/widgets/code/utils.ts
+++ b/widgets/code/utils.ts
@@ -47,6 +47,13 @@ function createTextWidget(pretitle: string, title: string, subtitle: string, col
     return w
 }
 
+export const logToWidget = (widget: ListWidget, message: string) => {
+    console.log(message)
+    let a = widget.addText(message)
+    a.textColor = Color.red()
+    a.textOpacity = 0.8
+    a.font = Font.systemFont(10)
+}
 
 function createErrorWidget(subtitle: string) {
     return createTextWidget("ERROR", "Widget Error", subtitle, "#000")

--- a/widgets/code/widgetLoader.ts
+++ b/widgets/code/widgetLoader.ts
@@ -1,16 +1,17 @@
-import { argsConfig, downloadWidgetModule, logToWidget, WidgetModule } from "./utils";
+import { getOrCreateWidgetModule, logToWidget, WidgetModule, widgetModuleDownloadConfig } from "./utils";
 const DEBUG = false;
+const FORCE_DOWNLOAD = false;
 const VERSION = "0.2";
 
-const widgetModulePath = await downloadWidgetModule(argsConfig)
+const widgetModulePath = await getOrCreateWidgetModule(widgetModuleDownloadConfig, FORCE_DOWNLOAD)
 const widgetModule: WidgetModule = importModule(widgetModulePath)
 const widget = await widgetModule.createWidget({
-    widgetParameter: args.widgetParameter || argsConfig.widgetParameter,
+    widgetParameter: args.widgetParameter || widgetModuleDownloadConfig.defaultWidgetParameter,
     debug: DEBUG
 });
 
 if (DEBUG) {
-    logToWidget(widget, argsConfig.widgetParameter)
+    logToWidget(widget, args.widgetParameter)
 }
 
 // preview the widget if in app

--- a/widgets/code/widgetLoader.ts
+++ b/widgets/code/widgetLoader.ts
@@ -1,31 +1,22 @@
-import { argsConfig, downloadWidgetModule, WidgetModule } from "./utils";
+import { argsConfig, downloadWidgetModule, logToWidget, WidgetModule } from "./utils";
 const DEBUG = false;
-const VERSION = "0.1";
+const VERSION = "0.2";
 
-downloadWidgetModule(argsConfig)
-    .then(async widgetModulePath => {
-        // import downloaded widgetModule
-        const widgetModule: WidgetModule = importModule(widgetModulePath)
-        // create the widget
-        const params = {
-            widgetParameter: args.widgetParameter || argsConfig.widgetParameter,
-            debug: DEBUG
-        }
-        const widget = await widgetModule.createWidget(params)
+const widgetModulePath = await downloadWidgetModule(argsConfig)
+const widgetModule: WidgetModule = importModule(widgetModulePath)
+const widget = await widgetModule.createWidget({
+    widgetParameter: args.widgetParameter || argsConfig.widgetParameter,
+    debug: DEBUG
+});
 
-        // preview the widget
-        if (!config.runsInWidget) {
-            await widget.presentSmall()
-        }
+if (DEBUG) {
+    logToWidget(widget, argsConfig.widgetParameter)
+}
 
-        Script.setWidget(widget)
-        Script.complete()
-    }).catch(error => {
-        console.error(error);
-    })
+// preview the widget if in app
+if (!config.runsInWidget) {
+    await widget.presentSmall()
+}
 
-
-
-
-
-
+Script.setWidget(widget)
+Script.complete()

--- a/widgets/rollup.config.js
+++ b/widgets/rollup.config.js
@@ -16,7 +16,7 @@ export default [
         input: 'code/widgetLoader.ts',
         output: {
             dir: '../scriptable-api/public/compiled-widgets/',
-            format: 'iife',
+            format: 'es',
             strict: false,
             banner: loaderBanner,
         },


### PR DESCRIPTION
- Use await-based for async download operation, instead of callback based. Should fix #1 🤞 
- Rollup /compile widgetLoader to `es` instead of `iife`. Necessary to make top-level await work
- Improve naming of some variables to make them easier to understand